### PR TITLE
fix: handling of custom schemas in users

### DIFF
--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -241,6 +241,11 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	// the initial password is not returned in the response, hence it must be read from the plan
 	state.InitialPassword = plan.InitialPassword
 
+	// if the custom schemas are not configured, set the value to null to prevent in place updates
+	if plan.CustomSchemas.IsNull() {
+		state.CustomSchemas = types.StringNull()
+	}
+
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -268,6 +273,11 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	// the initial password is not returned in the response, hence it must be read from the state
 	state.InitialPassword = config.InitialPassword
+
+	// if the custom schemas are not configured, set the value to null to prevent in place updates
+	if config.CustomSchemas.IsNull() {
+		state.CustomSchemas = types.StringNull()
+	}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -316,6 +326,11 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// the initial password is not returned in the response, hence it must be read from the plan
 	updatedState.InitialPassword = plan.InitialPassword
+
+	// if the custom schemas are not configured, set the value to null to prevent in place updates
+	if plan.CustomSchemas.IsNull() {
+		updatedState.CustomSchemas = types.StringNull()
+	}
 
 	diags = resp.State.Set(ctx, &updatedState)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
## Purpose
 
Partially addresses #114 

There is a schema attribute called `groups` as part of the user response which is not documented in the [Accelerator Hub APIs](https://api.sap.com/api/IdDS_SCIM/path/getUser).  Hence for users that are part of any groups, this parameter gets populated and is treated as a `custom_schema attribute` in the schema, as the undocumented `groups` parameter is not part of the `UserResponse` structure in the provider. 

![image](https://github.com/user-attachments/assets/614a08f8-4e53-4786-903d-d49993f58bcd)


This leads to unnecessary in-place updates of the user as the planned value of the `custom_schemas` (doesn't contain the groups parameter) is different from the state stored value, which is produced as a result of the Read operation on the `user` resource. To address this, a check has been put in place in the `READ`, `CREATE` and `UPDATE` operations of the resource to ensure consistency between the planned value and the state stored value of the parameter. 


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR status on the Project board is set (typically "in review").
- [x] The PR has the matching labels assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up issues are created and linked.
