### PR TITLE
fix: handle error code 500 in the resource sci_schema

### DIFF
--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -57,8 +57,11 @@ resource "sci_schema" "basic_schema" {
 
 Required:
 
+- `case_exact` (Boolean) Configure if the attribute must be case-sensitive or not.
+- `multivalued` (Boolean) Confgire if the attribute can have more than one value.
 - `mutability` (String) Control the Read or Write access of the attribute. Acceptable values are : `readOnly`, `readWrite`, `writeOnly`, `immutable`
 - `name` (String) The attribute name. Only alphanumeric characters and underscores are allowed.
+- `required` (Boolean) Configure if the attribute must be mandatory or not.
 - `returned` (String) Configure how the attribute's value must be returned. Acceptable values are : `always`, `never`, `default`, `request`
 - `type` (String) The attribute data type. Acceptable values are : `string`, `boolean`, `decimal`, `integer`, `dateTime`, `binary`, `reference`, `complex`
 - `uniqueness` (String) Define the context in which the attribute must be unique. Acceptable values are : `none`, `server`, `global`
@@ -66,9 +69,6 @@ Required:
 Optional:
 
 - `canonical_values` (List of String) A collection of suggested canonical values that may be used
-- `case_exact` (Boolean) Configure if the attribute must be case-sensitive or not.
 - `description` (String) A brief description for the attribute
-- `multivalued` (Boolean) Confgire if the attribute can have more than one value.
-- `required` (Boolean) Configure if the attribute must be mandatory or not.
 
 

--- a/internal/cli/apiObjects/schemas/schemas.go
+++ b/internal/cli/apiObjects/schemas/schemas.go
@@ -7,11 +7,11 @@ import (
 type Attribute struct {
 	Name            string   `json:"name,omitempty"`
 	Type            string   `json:"type,omitempty"`
-	Multivalued     bool     `json:"multivalued,omitempty"`
+	Multivalued     bool     `json:"multiValued"`
 	Description     string   `json:"description,omitempty"`
-	Required        bool     `json:"required,omitempty"`
+	Required        bool     `json:"required"`
 	CanonicalValues []string `json:"canonicalValues,omitempty"`
-	CaseExact       bool     `json:"caseExact,omitempty"`
+	CaseExact       bool     `json:"caseExact"`
 	Mutability      string   `json:"mutability,omitempty"`
 	Returned        string   `json:"returned,omitempty"`
 	Uniqueness      string   `json:"uniqueness,omitempty"`

--- a/sci/provider/resource_schema.go
+++ b/sci/provider/resource_schema.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
@@ -107,6 +105,18 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								stringvalidator.OneOf(attributeUniquenessValues...),
 							},
 						},
+						"multivalued": schema.BoolAttribute{
+							Required:            true,
+							MarkdownDescription: "Confgire if the attribute can have more than one value.",
+						},
+						"required": schema.BoolAttribute{
+							Required:            true,
+							MarkdownDescription: "Configure if the attribute must be mandatory or not.",
+						},
+						"case_exact": schema.BoolAttribute{
+							Required:            true,
+							MarkdownDescription: "Configure if the attribute must be case-sensitive or not.",
+						},
 						"canonical_values": schema.ListAttribute{
 							ElementType:         types.StringType,
 							Optional:            true,
@@ -115,33 +125,9 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								listvalidator.SizeAtLeast(1),
 							},
 						},
-						"multivalued": schema.BoolAttribute{
-							Optional:            true,
-							Computed:            true,
-							MarkdownDescription: "Confgire if the attribute can have more than one value.",
-							PlanModifiers: []planmodifier.Bool{
-								boolplanmodifier.UseStateForUnknown(),
-							},
-						},
 						"description": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "A brief description for the attribute",
-						},
-						"required": schema.BoolAttribute{
-							Optional:            true,
-							Computed:            true,
-							MarkdownDescription: "Configure if the attribute must be mandatory or not.",
-							PlanModifiers: []planmodifier.Bool{
-								boolplanmodifier.UseStateForUnknown(),
-							},
-						},
-						"case_exact": schema.BoolAttribute{
-							Optional:            true,
-							Computed:            true,
-							MarkdownDescription: "Configure if the attribute must be case-sensitive or not.",
-							PlanModifiers: []planmodifier.Bool{
-								boolplanmodifier.UseStateForUnknown(),
-							},
 						},
 					},
 				},

--- a/sci/provider/resource_schema_test.go
+++ b/sci/provider/resource_schema_test.go
@@ -108,7 +108,7 @@ func TestResourceSchema(t *testing.T) {
 		})
 	})
 
-	t.Run("error path - schema attributes has mandatory parameters : name, type, mutability, returned, uniqueness", func(t *testing.T) {
+	t.Run("error path - schema attributes has mandatory parameters : name, type, case_exact, multivalued, required, mutability, returned, uniqueness", func(t *testing.T) {
 
 		resource.Test(t, resource.TestCase{
 			IsUnitTest:               true,
@@ -116,7 +116,7 @@ func TestResourceSchema(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      ResourceSchemaWithoutAttributes("testSchema", "urn:ietf:scim:schemas:Terraform", "Terraform"),
-					ExpectError: regexp.MustCompile("Inappropriate value for attribute \"attributes\": element 0: attributes\n\"mutability\", \"name\", \"returned\", \"type\", and \"uniqueness\" are required."),
+					ExpectError: regexp.MustCompile("Inappropriate value for attribute \"attributes\": element 0: attributes\n\"case_exact\", \"multivalued\", \"mutability\", \"name\", \"required\", \"returned\",\n\"type\", and \"uniqueness\" are required."),
 				},
 			},
 		})


### PR DESCRIPTION
## Purpose

Addresses #175 

This PR addresses the ambiguous error `500` thrown when working with the resource `sci_schema`. 

As explained in the above mentioned issue, the error `500` is thrown when certain schema parameters, namely the **boolean attributes** have not been defined in the terraform configuration. The API expects the parameters `case_exact`, `required` and `multivalued` to be set to either true or false and **_must_** be part of the request payload.

The changes made to address this include:
- modify the terraform schema such that the above mentioned parameters are configured as `Required` attributes, this ensures that the attributes will always be defined
- modify the response object for Schemas by removing `omitempty` from the json tags for the boolean attributes, this ensures that the attributes will always be part of the request payload

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
