### PR TITLE
fix: throw an error for missing authentication credentials

### DIFF
--- a/sci/provider/provider.go
+++ b/sci/provider/provider.go
@@ -202,6 +202,7 @@ func (p *SciProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			},
 		}
 		cert = &tlsCert
+
 	} else {
 		httpClient = p.httpClient
 	}
@@ -233,6 +234,7 @@ func (p *SciProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			return
 		}
 		client.AuthorizationToken = "Bearer " + token
+
 	} else if cert == nil {
 		// Fallback to Basic Auth (username + password)
 		var username, password string
@@ -248,7 +250,11 @@ func (p *SciProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			password = config.Password.ValueString()
 		}
 
-		client.AuthorizationToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+		if username != "" && password != "" {
+			client.AuthorizationToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+		} else {
+			resp.Diagnostics.AddError("Authentication Details Missing", "Please provide either : \n- client_id and client_secret for OAuth2 Authentication \n- p12_certificate_content and p12_certificate_password for X.509 Authentication \n- username and password for Basic Authentication")
+		}
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/sci/provider/provider_test.go
+++ b/sci/provider/provider_test.go
@@ -28,6 +28,11 @@ type User struct {
 	Password string
 }
 
+var redactedTestUser = User{
+	Username: "test-user",
+	Password: "test-password",
+}
+
 type RoundTripperFunc func(req *http.Request) (*http.Response, error)
 
 func (f RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -67,7 +72,7 @@ func setupVCR(t *testing.T, cassetteName string) (*recorder.Recorder, User) {
 		t.Fatal(err)
 	}
 
-	var testUser User
+	testUser := redactedTestUser
 	if rec.IsRecording() {
 		t.Logf("Recording new interactions in '%s'", cassetteName)
 		testUser.Username = os.Getenv("SCI_USERNAME")
@@ -387,6 +392,25 @@ provider "sci" {
 data "sci_users" "test" {}
 `, invalidP12),
 				ExpectError: regexp.MustCompile("Invalid .p12 certificate"),
+			},
+		},
+	})
+}
+
+func TestMissing_Authentication_Credentials(t *testing.T) {
+	config := `
+provider "sci" {
+  tenant_url = "https://iasprovidertestblr.accounts400.ondemand.com/"
+
+  data "sci_users" "test" {}
+}`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: getTestProviders(http.DefaultClient),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("No valid authentication method provided. Please provide either : \n- client_id and client_secret for OAuth2 Authentication \n- p12_certificate_content and p12_certificate_password for X.509 Authentication \n- username and password for Basic Authentication"),
 			},
 		},
 	})


### PR DESCRIPTION
## Purpose

Closes #181 

As described in the issue linked, the provider does not validate missing authentication credentials before making the respective API calls. The error returned by the API response is simply propagated back which does not indicate the lack of authentication details.

This PR adds a check and throws a relevant error when credentials for at least one of the authentication mechanisms:
- OAuth
- X.509
- Basic

are not configured.

The provider test file has also been modified to adapt this change.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
