### PR TITLE
feat: added support of env variables for x509 auth

### DIFF
--- a/guides/cert_auth.md
+++ b/guides/cert_auth.md
@@ -4,7 +4,7 @@ You would require a valid **p12 certificate** and the corresponding **password**
  
 ```NOTE: Refer to step 6 in the documentation linked above, section Certificates to fetch the required credentials. ```
 
-You can only configure the credentials as part of the provider configuration as shown below:
+You can configure the credentials as part of the provider configuration as shown below:
 
  ```hcl
 provider "sci" {
@@ -17,3 +17,36 @@ provider "sci" {
 Ensure to paste the ***content*** of your p12 certificate rather than the ***file path***.
 You can even use the function `filebase64("path_to_certificate.p12")` to load the file content. 
 
+2. You can export the Certificate Password as an environment variable as shown below:
+
+    #### Windows 
+
+    If you use Windows CMD, do the export via the following commands:
+
+    ```Shell
+    set SCI_P12_CERTIFICATE_PASSWORD=<your_password>
+    ```
+
+    If you use Powershell, do the export via the following commands:
+
+    ```Shell
+    $Env:SCI_P12_CERTIFICATE_PASSWORD = '<your_password>'
+    ```
+
+    #### Mac
+
+    For Mac OS export the environment variable via:
+
+    ```Shell
+    export SCI_P12_CERTIFICATE_PASSWORD=<your_password>
+    ```
+
+    #### Linux
+
+    For Linux export the environment variable via:
+
+    ```Shell
+    export SCI_P12_CERTIFICATE_PASSWORD=<your_password>
+    ```
+
+    The P12 Certificate itself would still have to be configured as a schema parameter even if the password is exported as an environment variable.

--- a/sci/provider/provider.go
+++ b/sci/provider/provider.go
@@ -27,6 +27,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+const (
+	oauth2Flow = "oauth2"
+	x509Flow   = "x509"
+	basicFlow  = "basic"
+	none       = "none"
+)
+
 var (
 	basicAuthConflicts = []path.Expression{
 		path.MatchRoot("client_id"),
@@ -131,7 +138,6 @@ func (p *SciProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 				MarkdownDescription: "Base64-encoded content of the `.p12` (PKCS#12) certificate bundle file used for x509 authentication. For example you can use `filebase64(\"certifiacte.p12\")` to load the file content, But any source that provides a valid .p12 certificate base64 string is accepted.",
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(x509Conflicts...),
-					stringvalidator.AlsoRequires(path.MatchRoot("p12_certificate_password")),
 				},
 			},
 			"p12_certificate_password": schema.StringAttribute{
@@ -163,17 +169,61 @@ func (p *SciProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		return
 	}
 
-	var httpClient *http.Client
-	var cert *tls.Certificate
+	// OAuth2 Authentication using client_id and client_secret
+	clientID := config.ClientID.ValueString()
+	clientSecret := config.ClientSecret.ValueString()
 
-	if !config.P12CertificateContent.IsNull() && !config.P12CertificatePassword.IsNull() {
-		decoded, err := base64.StdEncoding.DecodeString(config.P12CertificateContent.ValueString())
+	if clientID == "" {
+		clientID = os.Getenv("SCI_CLIENT_ID")
+	}
+
+	if clientSecret == "" {
+		clientSecret = os.Getenv("SCI_CLIENT_SECRET")
+	}
+
+	// X.509 Certificate Authentication
+	p12CertificatePassword := config.P12CertificatePassword.ValueString()
+	if p12CertificatePassword == "" {
+		p12CertificatePassword = os.Getenv("SCI_P12_CERTIFICATE_PASSWORD")
+	}
+
+	p12CertificateContent := config.P12CertificateContent.ValueString()
+
+	// Basic Auth (username + password)
+	username := config.Username.ValueString()
+	password := config.Password.ValueString()
+
+	if username == "" {
+		username = os.Getenv("SCI_USERNAME")
+	}
+
+	if password == "" {
+		password = os.Getenv("SCI_PASSWORD")
+	}
+
+	client := cli.NewSciClient(cli.NewClient(p.httpClient, parsedUrl))
+
+	authFlow := determineAuthFlow(username, password, clientID, clientSecret, p12CertificateContent, p12CertificatePassword)
+
+	switch authFlow {
+	case "oauth2":
+		// OAuth2 authentication
+		token, err := fetchOAuthToken(p.httpClient, parsedUrl.String(), clientID, clientSecret)
+		if err != nil {
+			resp.Diagnostics.AddError("OAuth2 Authentication Failed", err.Error())
+			return
+		}
+		client.AuthorizationToken = "Bearer " + token
+
+	case "x509":
+		// X.509 authentication will be handled below
+		decoded, err := base64.StdEncoding.DecodeString(p12CertificateContent)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to decode base64 content", err.Error())
 			return
 		}
 
-		privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(decoded, config.P12CertificatePassword.ValueString())
+		privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(decoded, p12CertificatePassword)
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid .p12 certificate", err.Error())
 			return
@@ -195,69 +245,28 @@ func (p *SciProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			InsecureSkipVerify: false,
 		}
 
-		httpClient = &http.Client{
+		httpClient := &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConfig,
 			},
 		}
-		cert = &tlsCert
 
-	} else {
-		httpClient = p.httpClient
-	}
+		client = cli.NewSciClient(cli.NewClient(httpClient, parsedUrl))
 
-	client := cli.NewSciClient(cli.NewClient(httpClient, parsedUrl))
+	case "basic":
+		// Basic authentication will be handled below
+		client.AuthorizationToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
 
-	// OAuth2 authentication using client_id and client_secret
-	var clientID, clientSecret string
-	if config.ClientID.IsNull() {
-		clientID = os.Getenv("SCI_CLIENT_ID")
-	} else {
-		clientID = config.ClientID.ValueString()
-	}
+	default:
+		incompleteCreds, err := checkIncompleteCredentials(username, password, clientID, clientSecret, p12CertificateContent, p12CertificatePassword)
 
-	if config.ClientSecret.IsNull() {
-		clientSecret = os.Getenv("SCI_CLIENT_SECRET")
-	} else {
-		clientSecret = config.ClientSecret.ValueString()
-	}
-
-	if clientID != "" && clientSecret != "" {
-		if cert != nil {
-			resp.Diagnostics.AddWarning("Multiple authentication methods detected", "Both client credentials and certificate-based authentication are provided. Client credentials will be used.")
-		}
-
-		token, err := fetchOAuthToken(httpClient, parsedUrl.String(), clientID, clientSecret)
-		if err != nil {
-			resp.Diagnostics.AddError("OAuth2 Authentication Failed", err.Error())
+		if incompleteCreds {
+			resp.Diagnostics.AddError(err, "Please provide all required fields.")
 			return
 		}
-		client.AuthorizationToken = "Bearer " + token
 
-	} else if cert == nil {
-		// Fallback to Basic Auth (username + password)
-		var username, password string
-		if config.Username.IsNull() {
-			username = os.Getenv("SCI_USERNAME")
-		} else {
-			username = config.Username.ValueString()
-		}
-
-		if config.Password.IsNull() {
-			password = os.Getenv("SCI_PASSWORD")
-		} else {
-			password = config.Password.ValueString()
-		}
-
-		if username != "" && password != "" {
-			client.AuthorizationToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
-		} else {
-			resp.Diagnostics.AddError("Authentication Details Missing", "Please provide either : \n- client_id and client_secret for OAuth2 Authentication \n- p12_certificate_content and p12_certificate_password for X.509 Authentication \n- username and password for Basic Authentication")
-		}
-	}
-
-	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError("Authentication Details Missing", "Please provide either : \n- client_id and client_secret for OAuth2 Authentication \n- p12_certificate_content and p12_certificate_password for X.509 Authentication \n- username and password for Basic Authentication")
 		return
 	}
 
@@ -311,4 +320,34 @@ func fetchOAuthToken(httpClient *http.Client, tenantURL, clientID, clientSecret 
 	}
 
 	return token.AccessToken, nil
+}
+
+func determineAuthFlow(username, password, clientID, clientSecret, p12CertificateContent, p12CertificatePassword string) string {
+
+	if len(clientID)!= 0 && len(clientSecret)!=0 {
+		return oauth2Flow
+	} else if len(p12CertificateContent)!=0 && len(p12CertificatePassword)!=0 {
+		return x509Flow
+	} else if len(username)!=0 && len(password)!=0 {
+		return basicFlow
+	} else {
+		return none
+	}
+}
+
+func checkIncompleteCredentials(username, password, clientID, clientSecret, p12CertificateContent, p12CertificatePassword string) (bool, string) {
+
+	if len(clientID) != 0 || len(clientSecret) != 0 {
+		return true, "Incomplete OAuth Credentials"
+	}
+
+	if len(p12CertificateContent) != 0 || len(p12CertificatePassword) != 0 {
+		return true, "Incomplete X.509 Authentication Credentials"
+	}
+
+	if len(username) != 0 || len(password) != 0 {
+		return true, "Incomplete Basic Authentication Credentials"
+	}
+
+	return false, ""
 }


### PR DESCRIPTION
## Purpose

Closes #188

This PR brings in the support of configuring the P12 Certificate Password used for the x509 authentication flow as an environment variable. The supported parameter is `SCI_P12_CERTIFICATE_PASSWORD`.

Changes made as part of the PR:
- Code cleanup in the file `provider.go` to better structure the authentication flows. Also added checks for incomplete credentials
- Modified the test suites in the file `provider_test.go` to combine similar test runs and added mock server setups to test the OAuth2 and X509 Authentication flows


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
