### PR TITLE
fix: handling of inconsistent apply on resource sci_application for parameter `authentication_schema.conditional_authentication.*.identity_provider_id`

### DIFF
--- a/sci/provider/resource_application.go
+++ b/sci/provider/resource_application.go
@@ -960,6 +960,34 @@ func stateModify(ctx context.Context, plan applicationData, state *applicationDa
 			stateData.DefaultAuthenticatingIdpId = planData.DefaultAuthenticatingIdpId
 		}
 
+		// do the same for the Conditional Authentication parameter
+		if !planData.AuthenticationRules.IsNull() && !planData.AuthenticationRules.IsUnknown() {
+
+			var planAuthRulesData []authenticationRulesData
+			diags = planData.AuthenticationRules.ElementsAs(ctx, &planAuthRulesData, true)
+			if diags.HasError() {
+				return diags
+			}
+
+			var stateAuthRulesData []authenticationRulesData
+			diags = stateData.AuthenticationRules.ElementsAs(ctx, &stateAuthRulesData, true)
+			if diags.HasError() {
+				return diags
+			}
+
+			for i, rule := range planAuthRulesData {
+				if !rule.IdentityProviderId.IsNull() && !rule.IdentityProviderId.IsUnknown() {
+					stateAuthRulesData[i].IdentityProviderId = rule.IdentityProviderId
+				}
+			}
+
+			stateData.AuthenticationRules, diags = types.ListValueFrom(ctx, authenticationRulesObjType, stateAuthRulesData)
+			if diags.HasError() {
+				return diags
+			}
+
+		}
+
 		state.AuthenticationSchema, diags = types.ObjectValueFrom(ctx, authenticationSchemaObjType, stateData)
 		if diags.HasError() {
 			return diags

--- a/sci/provider/resource_application_test.go
+++ b/sci/provider/resource_application_test.go
@@ -184,7 +184,7 @@ func TestResourceApplication(t *testing.T) {
 			},
 		})
 	})
-	
+
 	t.Run("happy path - bundled application1", func(t *testing.T) {
 
 		rec, user := setupVCR(t, "fixtures/resource_bundled_application1")

--- a/sci/provider/type_application.go
+++ b/sci/provider/type_application.go
@@ -716,7 +716,7 @@ func getApplicationRequest(ctx context.Context, plan applicationData) (*applicat
 
 		// SAP MANAGED ATTRIBUTES
 		if !authenticationSchema.SapManagedAttributes.IsNull() && !authenticationSchema.SapManagedAttributes.IsUnknown() {
-			
+
 			var sapManagedAttributes sapManagedAttributesData
 			diags := authenticationSchema.SapManagedAttributes.As(ctx, &sapManagedAttributes, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    true,
@@ -730,7 +730,7 @@ func getApplicationRequest(ctx context.Context, plan applicationData) (*applicat
 			// reflect over the sapManagedAttributesData to set the attributes in the API request body
 			// this avoids multiple if statements for each attribute
 			// also helps to determine if at least one attribute is set, to decide whether to set the object in the request body or leave it as nil
-		
+
 			var attributes applications.SapManagedAttributes
 			attributesVal := reflect.ValueOf(&attributes)
 
@@ -755,7 +755,7 @@ func getApplicationRequest(ctx context.Context, plan applicationData) (*applicat
 			}
 
 			if setAttributes {
-				attributes = attributesVal.Elem().Interface().(applications.SapManagedAttributes)	
+				attributes = attributesVal.Elem().Interface().(applications.SapManagedAttributes)
 				args.AuthenticationSchema.SapManagedAttributes = &attributes
 			} else {
 				args.AuthenticationSchema.SapManagedAttributes = nil


### PR DESCRIPTION
## Purpose

This PR addresses the inconsistent apply faced when configuring the resource `sci_application` with the parameter `identity_provider_id` in `authentication_schema.conditional_authentication`. The error occurs since the GET API for the resource now returns the internal id instead of the UUID, even when configured with the UUID of the idp. The same issue was faced earlier with the parameter `authentication_schema.default_authenticating_idp` as described in : #142.

Thus, the parameter is now handled in the same manner as the parameter `authentication_schema.default_authenticating_idp` as seen in #176. Essentially modifying the state value before it is saved.

Closes #233 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
