### PR TITLE
chore: new terraform cli version added to test matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: What version of the Terraform CLI are you using?
       description: What version of the Terraform CLI are you using?
-      placeholder: 1.14.0
+      placeholder: 1.15.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ permissions:
 
 # Define the latest Terraform version to use for upload of coverage report
 env:
-  LATEST_TF_VERSION: 1.14.*
+  LATEST_TF_VERSION: 1.15.*
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -114,10 +114,11 @@ jobs:
         # '1.9.*' #end of security support 27 Feb 2025
         # '1.10.*' end of security support 14 May 2025
         # '1.11.*' end of security support 20 Aug 2025
+        # '1.12.*' end of security support 19 Nov 2025
         terraform:
-          - "1.12.*"
           - "1.13.*"
           - "1.14.*"
+          - "1.15.0"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
         terraform:
           - "1.13.*"
           - "1.14.*"
-          - "1.15.0"
+          - "1.15.*"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
## Purpose

Closes #363 

Latest CLI version for terraform updated in required workflows. Outdated version `1.12.*` has been removed from the test matrix.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe: Workflow change
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
