### PR TITLE
fix: allow saml2_config.assertion_attributes for openIdConnect Corporate IdPs

### DIFF
--- a/sci/provider/resource_corporateIdP.go
+++ b/sci/provider/resource_corporateIdP.go
@@ -199,13 +199,7 @@ func (r *corporateIdPResource) Schema(_ context.Context, _ resource.SchemaReques
 					),
 					// The API does not validate the type of the corporate IdP depending on the configuration provided.
 					// When the saml2 configuration is provided but the type of the IdP is set to "openIdConnect", the IdP listed on the Admin Console is of type OIDC.
-					// Although the provided saml2 configuration details are returned in the GET call, this validator ensures the consistency of the type and config provided
-					objectvalidator.All(
-						utils.ValidType(
-							path.MatchRoot("type"),
-							idpTypeValues[:3],
-						),
-					),
+					// The saml2_config.assertion_attributes field is used for Enriched Token Claims which are valid for all IdP types, including OIDC.
 				},
 				Attributes: map[string]schema.Attribute{
 					"saml_metadata_url": schema.StringAttribute{


### PR DESCRIPTION
## Purpose
- Remove the client-side type validator that restricted `saml2_config` to only `sapSSO`, `microsoftADFS`, and `saml2` type Corporate IdPs
- The IAS API already supports `saml2_config.assertion_attributes` (Enriched Token Claims) on OIDC Corporate IdPs — the existing validator was overly restrictive

### Motivation

Enriched Token Claims (configured via `saml2_config.assertion_attributes`) are needed on OIDC Corporate IdPs to enrich tokens with additional attributes (e.g., mapping a `NameID` claim).

The IAS API accepts this configuration without issue — when `saml2_config` is provided with `type = "openIdConnect"`, the IdP remains OIDC in the Admin Console, and the enriched claims work correctly. The existing comment in the code already acknowledges this behavior:

> "The API does not validate the type of the corporate IdP depending on the configuration provided. When the saml2 configuration is provided but the type of the IdP is set to 'openIdConnect', the IdP listed on the Admin Console is of type OIDC."

### Example usage

```hcl
resource "sci_corporate_idp" "example" {
  name         = "example-oidc-idp"
  display_name = "example-oidc-idp"
  type         = "openIdConnect"

  oidc_config = {
    discovery_url = "https://example.com/.well-known/openid-configuration"
    client_id     = var.client_id
    client_secret = var.client_secret
  }

  saml2_config = {
    assertion_attributes = [
      { name = "NameID", value = "user@example.com" }
    ]
  }

  identity_federation = {
    use_local_user_store = false
  }
}
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- [ ] Verify `terraform validate` passes with `saml2_config.assertion_attributes` on an `openIdConnect` type Corporate IdP
- [ ] Verify `terraform apply` creates the Corporate IdP with enriched claims correctly configured
- [ ] Verify `terraform plan` (refresh) shows no drift after apply
- [ ] Existing tests still pass (no SAML2-type behavior changed)

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.

