### PR TITLE
fix: disabling fail-fast to allow multiple retries for integration workflows

### DIFF
--- a/.github/workflows/ot-integration-canary-main.yml
+++ b/.github/workflows/ot-integration-canary-main.yml
@@ -55,10 +55,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e 
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
-          
+
           MAX_RETRIES=3
           RETRY_DELAY=10
 
@@ -72,10 +70,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
-            EXIT_CODE=$?
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -101,8 +98,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e 
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -118,10 +113,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
-            EXIT_CODE=$?
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/ot-integration-canary-main.yml
+++ b/.github/workflows/ot-integration-canary-main.yml
@@ -55,6 +55,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e 
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
           
           MAX_RETRIES=3
@@ -71,7 +73,6 @@ jobs:
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
               -auto-approve -no-color
-          
             EXIT_CODE=$?
 
             if [ $EXIT_CODE -eq 0 ]; then
@@ -100,6 +101,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e 
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -116,7 +119,6 @@ jobs:
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
               -auto-approve -no-color
-
             EXIT_CODE=$?
 
             if [ $EXIT_CODE -eq 0 ]; then

--- a/.github/workflows/ot-integration-canary-stable.yml
+++ b/.github/workflows/ot-integration-canary-stable.yml
@@ -48,6 +48,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -93,6 +95,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/ot-integration-canary-stable.yml
+++ b/.github/workflows/ot-integration-canary-stable.yml
@@ -48,8 +48,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -65,11 +63,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -95,8 +91,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -112,11 +106,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/ot-integration-live-main.yml
+++ b/.github/workflows/ot-integration-live-main.yml
@@ -55,8 +55,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -72,11 +70,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -102,8 +98,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -119,11 +113,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/ot-integration-live-main.yml
+++ b/.github/workflows/ot-integration-live-main.yml
@@ -55,6 +55,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -100,6 +102,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/ot-integration-live-stable.yml
+++ b/.github/workflows/ot-integration-live-stable.yml
@@ -48,8 +48,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -65,11 +63,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
-            
-            EXIT_CODE=$?
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -95,8 +91,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -112,11 +106,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Tofu apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/ot-integration-live-stable.yml
+++ b/.github/workflows/ot-integration-live-stable.yml
@@ -48,6 +48,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -93,6 +95,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/tf-integration-canary-main.yml
+++ b/.github/workflows/tf-integration-canary-main.yml
@@ -56,8 +56,10 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
-          
+
           MAX_RETRIES=3
           RETRY_DELAY=10
 
@@ -101,6 +103,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/tf-integration-canary-main.yml
+++ b/.github/workflows/tf-integration-canary-main.yml
@@ -56,8 +56,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -73,11 +71,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
-          
-            EXIT_CODE=$?
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -103,8 +99,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -120,11 +114,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/tf-integration-canary-stable.yml
+++ b/.github/workflows/tf-integration-canary-stable.yml
@@ -49,6 +49,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -94,6 +96,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/tf-integration-canary-stable.yml
+++ b/.github/workflows/tf-integration-canary-stable.yml
@@ -49,8 +49,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -66,11 +64,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -96,8 +92,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.CANARY_P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -113,11 +107,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/tf-integration-live-main.yml
+++ b/.github/workflows/tf-integration-live-main.yml
@@ -56,6 +56,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -101,6 +103,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3

--- a/.github/workflows/tf-integration-live-main.yml
+++ b/.github/workflows/tf-integration-live-main.yml
@@ -56,8 +56,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -73,11 +71,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -103,8 +99,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -120,11 +114,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/tf-integration-live-stable.yml
+++ b/.github/workflows/tf-integration-live-stable.yml
@@ -49,8 +49,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -66,11 +64,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
-            
-            EXIT_CODE=$?
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0
@@ -96,8 +92,6 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
-          set +e
-
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -113,11 +107,9 @@ jobs:
               -var certificate_file_path="cert.p12" \
               -var certificate_file_password="${{ secrets.P12_CERTIFICATE_PASSWORD }}" \
               -var certificate="${{ secrets.PEM_CERTIFICATE_STRING }}" \
-              -auto-approve -no-color
+              -auto-approve -no-color || EXIT_CODE=$?
 
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -eq 0 ]; then
+            if [ ${EXIT_CODE:-0} -eq 0 ]; then
               echo "Terraform apply succeeded"
               echo "attempts=$i" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/tf-integration-live-stable.yml
+++ b/.github/workflows/tf-integration-live-stable.yml
@@ -49,6 +49,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3
@@ -94,6 +96,8 @@ jobs:
           P12_CERTIFICATE_BASE64_STRING: ${{ secrets.P12_CERTIFICATE_BASE64_STRING }}
           PATH_TO_TFSCRIPT: ${{ env.PATH_TO_TFSCRIPT }}
         run: |
+          set +e
+
           echo "$P12_CERTIFICATE_BASE64_STRING" | base64 --decode > $PATH_TO_TFSCRIPT/cert.p12
 
           MAX_RETRIES=3


### PR DESCRIPTION
## Purpose

Added an additional step in the integration workflows for Terraform and OpenTofu to allow multiple retries of both the terraform `apply` and `destroy` commands

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR status on the Project board is set (typically "in review").
- [x] The PR has the matching labels assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up issues are created and linked.
