### PR TITLE
feat: plan modifier added to parameter `name`

### DIFF
--- a/sci/provider/resource_group.go
+++ b/sci/provider/resource_group.go
@@ -126,6 +126,7 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 					"description": schema.StringAttribute{


### PR DESCRIPTION
## Purpose

Closes #386 

The plan modifier `RequiresReplace()` is added to the parameter `group_extension.name` to enable recreating a group when the name is modified.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
